### PR TITLE
changes so the mac install script works correctly

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-LEARNING_GITHUB_CALLBACK=http://localhost:3000/auth/github
+VIRTUAL_ENV=/Users/matthewgill/Artemis/learning-platform-api/venv

--- a/LearningPlatform/settings.py
+++ b/LearningPlatform/settings.py
@@ -124,6 +124,8 @@ DATABASES = {
     }
 }
 
+
+
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
Troubleshooting the install script on Matt's machine:

- We DEFINITELY set up environment vars in his .zshrc
- Changed $USER param to $DB_USER to avoid overshadowing with the standard linux $USER variable
- Added DB statements to give the created user ownership over the public schema so that we could also give them the appropriate permissions
-  The script did run all the way through correctly